### PR TITLE
Fix issue#16

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -1,7 +1,6 @@
 name: Run-All-Test
 
 on:
-  - push
   - pull_request
   - workflow_call
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unflare",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unflare",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@types/cookie": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unflare",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "engines": {
     "node": ">=18"
   },

--- a/src/api/core/unflare.test.ts
+++ b/src/api/core/unflare.test.ts
@@ -197,4 +197,31 @@ describe('.beforeEach() and .afterEach()', () => {
 
     expect(sequence).toBe('---22b2b2');
   });
+
+  it('req, res, ENV and env should defined during execution of .beforeEach!', () => {
+    const app = new Unflare();
+
+    app.get('/', () => {
+      const { req } = app;
+      expect(req.data.beforeEachRunTimes).toBe(1);
+    });
+
+    app.beforeEach(() => {
+      const { req, res, env, ENV } = app;
+      expect(req).toBeDefined();
+      expect(res).toBeDefined();
+      expect(env).toBeDefined();
+      expect(ENV).toBeDefined();
+      expect(env.SOME_VARS).toBe('YO!');
+      if (!req.data.beforeEachRunTimes) req.data.beforeEachRunTimes = 0;
+
+      req.data.beforeEachRunTimes += 1;
+    });
+
+    const sample_request = new Request('http://example.com/', {
+      method: 'GET',
+    });
+
+    app.fetch(sample_request, { SOME_VARS: 'YO!' });
+  });
 });

--- a/src/api/core/unflare.ts
+++ b/src/api/core/unflare.ts
@@ -7,9 +7,6 @@ export interface UnflareOptions {
 }
 
 export class Unflare extends Router {
-  #pre_fetch: Function[] = [];
-  #post_fetch: Function[] = [];
-
   strict: boolean = false;
 
   constructor(
@@ -41,14 +38,6 @@ export class Unflare extends Router {
     this.createNotFoundResponse = creator;
   }
 
-  beforeEach(...args: Function[]): void {
-    this.#pre_fetch.push(...args);
-  }
-
-  afterEach(...args: Function[]): void {
-    this.#post_fetch.push(...args);
-  }
-
   static Router(): Router {
     return new Router();
   }
@@ -68,9 +57,7 @@ export class Unflare extends Router {
     let err: any = false;
 
     try {
-      this.#pre_fetch.forEach(async (e) => await e.apply(this));
       await this.tryToHandle(reqer, reser, env);
-      this.#post_fetch.forEach(async (e) => await e.apply(this));
     } catch (e: any) {
       console.error(e);
       err = e;


### PR DESCRIPTION
- Fixed the bug: `ENV` is undefined during execution of `.beforeEach()`
- New feature: new extractable asset: `env` so that `ENV` can now be accessed in lowercase. 
- Remove `push` trigger in Run-All-Test github actions.